### PR TITLE
fixed top ranking bug

### DIFF
--- a/core/kdr_core.py
+++ b/core/kdr_core.py
@@ -221,19 +221,19 @@ class KDRCore(Cog):
         
         if length>50: length=50
 
-        col_users=list(col_users.sort("elo",-1).limit(length))
+        col_users=list(col_users.sort("elo",-1))
         if len(col_users)==0:
             await interaction.followup.send(f"{OOPS}\n No Users have Played in KDRs yet in this server.",ephemeral=True)
-
+        filtered_users = [user for user in col_users if user["elo"] != DEFAULT_ELO_RANKING]
+        filtered_users = filtered_users[:length]
 
         msg=f"The KDR Elo Ranking top {length} for this server is as follows: \n"
         rank=1
-        for player in col_users:
+        for player in filtered_users:
             playerid=player["id_player"]
             playerelo=int(player["elo"])
-            if playerelo!=DEFAULT_ELO_RANKING:
-                msg+=f"{rank} - <@{playerid}> (Elo: {playerelo})\n"
-                rank+=1
+            msg+=f"{rank} - <@{playerid}> (Elo: {playerelo})\n"
+            rank+=1
 
         await interaction.followup.send(msg,ephemeral=True)
 


### PR DESCRIPTION
The bug was that col_users was getting users with default elo in it and that those users were not shown in the ranking, but were still being counted in the length of col_users. This meant that if, for example, get_top_ranking was called with length=25, but there were 9 users with default elo in those 25, then only 16 users would be shown. I have edited the code such that all the users with default elo are removed from the list.
There's a choice to be made whether the filtering should be after or before the if statement on line 225, but I figured it makes more sense after.